### PR TITLE
Fix issue with type inference

### DIFF
--- a/src/sign1.rs
+++ b/src/sign1.rs
@@ -113,7 +113,7 @@ impl CoseSign1 {
                 }
                 Value::Text(alg_value_str) => {
                     // If alg header does not parse as an i32; ignore and carry on verification.
-                    if let Ok(alg_value) = alg_value_str.parse() {
+                    if let Ok(alg_value) = alg_value_str.parse::<i32>() {
                         if verifier.algorithm().value() != alg_value {
                             return VerificationResult::Failure(
                                 "algorithm in protected headers did not match verifier's algorithm"


### PR DESCRIPTION
In-scope implementations of `PartialEq` for `i32` cause a type inference error here, as Rust cannot determine what type `alg_value` should be.