### PR TITLE
Keys and headers

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -1,4 +1,5 @@
 use crate::header_map::Header;
+use serde::de::Error;
 use serde_cbor::Value;
 use std::convert::TryFrom;
 use std::fmt;
@@ -378,7 +379,7 @@ impl Header for Algorithm {
 
 impl From<Algorithm> for Value {
     fn from(value: Algorithm) -> Self {
-        Value::Text(value.to_string())
+        Value::Integer(value.value().into())
     }
 }
 
@@ -386,7 +387,9 @@ impl TryFrom<Value> for Algorithm {
     type Error = serde_cbor::Error;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        Ok(serde_cbor::value::from_value::<String>(value)?.parse()?)
+        serde_cbor::value::from_value::<i32>(value)?
+            .try_into()
+            .map_err(serde_cbor::Error::custom)
     }
 }
 

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -1,3 +1,5 @@
+use crate::header_map::Header;
+use serde_cbor::Value;
 use std::convert::TryFrom;
 use std::fmt;
 
@@ -8,7 +10,7 @@ pub trait SignatureAlgorithm {
 
 /// COSE algorithms from the
 /// [IANA COSE Algorithms registry](https://www.iana.org/assignments/cose/cose.xhtml#algorithms).
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum Algorithm {
     RS1,
     WalnutDSA,
@@ -365,6 +367,26 @@ impl TryFrom<i32> for Algorithm {
 impl fmt::Display for Algorithm {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.name())
+    }
+}
+
+impl Header for Algorithm {
+    fn key() -> crate::header_map::Key {
+        crate::header_map::Key::Integer(1)
+    }
+}
+
+impl From<Algorithm> for Value {
+    fn from(value: Algorithm) -> Self {
+        Value::Text(value.to_string())
+    }
+}
+
+impl TryFrom<Value> for Algorithm {
+    type Error = serde_cbor::Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Ok(serde_cbor::value::from_value::<String>(value)?.parse()?)
     }
 }
 

--- a/src/cwt/claim.rs
+++ b/src/cwt/claim.rs
@@ -67,7 +67,7 @@ pub enum Error {
 /// Numerical representation of seconds relative to the Unix Epoch,
 /// as defined in [RFC7049](https://www.rfc-editor.org/rfc/rfc7049#section-2.4.1)
 /// with the leading tag 1 omitted.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd)]
 #[serde(try_from = "Value", into = "Value")]
 pub enum NumericDate {
     IntegerSeconds(i128),
@@ -100,7 +100,7 @@ impl TryFrom<Value> for NumericDate {
 /// Custom value_type's must implement From<value_type> for serde_cbor::Value.
 macro_rules! define_claim {
     ($name:ident, $value_type: ty, $key: expr) => {
-        #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+        #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd)]
         pub struct $name(pub $value_type);
         impl $name {
             pub fn new(value: $value_type) -> $name {
@@ -137,7 +137,7 @@ define_claim!(ExpirationTime, NumericDate, Key::Integer(4));
 define_claim!(NotBefore, NumericDate, Key::Integer(5));
 define_claim!(IssuedAt, NumericDate, Key::Integer(6));
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[serde(try_from = "Value", into = "Value")]
 pub struct CWTId(Vec<u8>);
 impl CWTId {

--- a/src/cwt/claim.rs
+++ b/src/cwt/claim.rs
@@ -10,7 +10,7 @@ pub trait Claim: Into<Value> + TryFrom<Value, Error = Error> {
 /// Representation of the CBOR map key used to identify a claim
 /// within a CWT claims set, and restricted to text and integer values,
 /// per [RFC8392](https://datatracker.ietf.org/doc/html/rfc8392).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
 #[serde(try_from = "Value", into = "Value")]
 pub enum Key {
     Text(String),
@@ -38,6 +38,18 @@ impl TryFrom<Value> for Key {
                 invalid_key_type
             ))),
         }
+    }
+}
+
+impl From<String> for Key {
+    fn from(key: String) -> Self {
+        Key::Text(key)
+    }
+}
+
+impl From<i128> for Key {
+    fn from(key: i128) -> Self {
+        Key::Integer(key)
     }
 }
 

--- a/src/header_map.rs
+++ b/src/header_map.rs
@@ -1,3 +1,7 @@
+pub use crate::cwt::{
+    claim::{Claim, Key},
+    Error,
+};
 use serde::{Deserialize, Serialize};
 use serde_cbor::Value;
 use std::collections::BTreeMap;
@@ -5,46 +9,149 @@ use std::ops::Deref;
 
 /// COSE headers.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-pub struct HeaderMap(BTreeMap<Value, Value>);
+pub struct HeaderMap(BTreeMap<Key, Value>);
 
 impl HeaderMap {
+    /// Insert a defined CWT header struct.
+    /// Returns an error if the previous value found cannot be parsed
+    /// into the expected header structure.
+    pub fn insert_claim<T: Header>(&mut self, claim: T) -> Result<Option<T>, Error> {
+        match self.0.insert(T::key(), claim.into()) {
+            None => Ok(None),
+            Some(v) => v.try_into().map_or_else(
+                |e: serde_cbor::Error| Err(Error::UnableToParseClaim(e.into())),
+                |claim| Ok(Some(claim)),
+            ),
+        }
+    }
+
+    /// Insert a header with a given key.
+    pub fn insert<T: Into<Key>>(&mut self, key: T, value: Value) -> Option<Value> {
+        self.0.insert(key.into(), value)
+    }
+
     /// Insert a header with an integer label.
     pub fn insert_i<L: Into<i128>>(&mut self, label: L, value: Value) -> Option<Value> {
-        self.0.insert(Value::Integer(label.into()), value)
+        self.0.insert(Key::Integer(label.into()), value)
     }
 
     /// Insert a header with a text label.
     pub fn insert_t<L: Into<String>>(&mut self, label: L, value: Value) -> Option<Value> {
-        self.0.insert(Value::Text(label.into()), value)
+        self.0.insert(Key::Text(label.into()), value)
+    }
+
+    /// Retrieve a header value with a given key.
+    pub fn get<T: Into<Key>>(&self, key: T) -> Option<&Value> {
+        self.0.get(&key.into())
     }
 
     /// Retrieve a header value with an integer label.
     pub fn get_i<L: Into<i128>>(&self, label: L) -> Option<&Value> {
-        self.0.get(&Value::Integer(label.into()))
+        self.0.get(&Key::Integer(label.into()))
     }
 
     /// Retrieve a header value with a text label.
     pub fn get_t<L: Into<String>>(&self, label: L) -> Option<&Value> {
-        self.0.get(&Value::Text(label.into()))
+        self.0.get(&Key::Text(label.into()))
+    }
+
+    /// Remove a defined CWT header struct.
+    /// Returns an error if the removed value cannot be parsed into
+    /// the expected header structure.
+    pub fn remove_claim<T: Header>(&mut self) -> Result<Option<T>, Error> {
+        match self.0.remove(&T::key()) {
+            None => Ok(None),
+            Some(v) => v.try_into().map_or_else(
+                |e: serde_cbor::Error| Err(Error::UnableToParseClaim(e.into())),
+                |claim| Ok(Some(claim)),
+            ),
+        }
+    }
+
+    /// Remove a header value with a given key.
+    pub fn remove<T: Into<Key>>(&mut self, key: T) -> Option<Value> {
+        self.0.remove(&key.into())
+    }
+
+    /// Remove a header value with an integer key.
+    pub fn remove_i<T: Into<i128>>(&mut self, key: T) -> Option<Value> {
+        self.0.remove(&Key::Integer(key.into()))
+    }
+
+    /// Remove a claim value with a text key.
+    pub fn remove_t<T: Into<String>>(&mut self, key: T) -> Option<Value> {
+        self.0.remove(&Key::Text(key.into()))
     }
 }
 
-impl AsRef<BTreeMap<Value, Value>> for HeaderMap {
-    fn as_ref(&self) -> &BTreeMap<Value, Value> {
+impl AsRef<BTreeMap<Key, Value>> for HeaderMap {
+    fn as_ref(&self) -> &BTreeMap<Key, Value> {
         &self.0
     }
 }
 
 impl Deref for HeaderMap {
-    type Target = BTreeMap<Value, Value>;
+    type Target = BTreeMap<Key, Value>;
 
-    fn deref(&self) -> &BTreeMap<Value, Value> {
+    fn deref(&self) -> &BTreeMap<Key, Value> {
         &self.0
     }
 }
 
-impl From<BTreeMap<Value, Value>> for HeaderMap {
-    fn from(m: BTreeMap<Value, Value>) -> Self {
+impl From<BTreeMap<Key, Value>> for HeaderMap {
+    fn from(m: BTreeMap<Key, Value>) -> Self {
         Self(m)
     }
 }
+
+impl IntoIterator for HeaderMap {
+    type Item = (Key, Value);
+
+    type IntoIter = <BTreeMap<Key, Value> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+pub trait Header: Into<Value> + TryFrom<Value, Error = serde_cbor::Error> {
+    fn key() -> Key;
+}
+
+/// Simple macro for defining generic claims with implementations of
+/// the Claim and From<> for serde_cbor::Value traits.
+/// Custom value_type's must implement From<value_type> for serde_cbor::Value.
+macro_rules! define_header {
+    ($name:ident, $value_type: ty, $key: expr) => {
+        #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+        pub struct $name($value_type);
+        impl $name {
+            pub fn new(value: $value_type) -> $name {
+                $name(value)
+            }
+        }
+
+        impl Header for $name {
+            fn key() -> Key {
+                $key
+            }
+        }
+
+        impl From<$name> for Value {
+            fn from(value: $name) -> Self {
+                value.0.into()
+            }
+        }
+
+        impl TryFrom<Value> for $name {
+            type Error = serde_cbor::Error;
+
+            fn try_from(value: Value) -> Result<Self, Self::Error> {
+                Ok(Self(serde_cbor::value::from_value(value)?))
+            }
+        }
+    };
+}
+
+define_header!(Algorithm, String, Key::Integer(1));
+define_header!(X5Chain, Vec<u8>, Key::Integer(33));

--- a/src/header_map.rs
+++ b/src/header_map.rs
@@ -98,6 +98,22 @@ impl Deref for HeaderMap {
     }
 }
 
+impl FromIterator<(Key, Value)> for HeaderMap {
+    fn from_iter<T: IntoIterator<Item = (Key, Value)>>(iter: T) -> Self {
+        Self(BTreeMap::from_iter(iter))
+    }
+}
+
+impl TryFrom<BTreeMap<Value, Value>> for HeaderMap {
+    type Error = Error;
+
+    fn try_from(m: BTreeMap<Value, Value>) -> Result<Self, Self::Error> {
+        m.into_iter()
+            .map(|(k, v)| Ok((Key::try_from(k)?, v)))
+            .collect()
+    }
+}
+
 impl From<BTreeMap<Key, Value>> for HeaderMap {
     fn from(m: BTreeMap<Key, Value>) -> Self {
         Self(m)

--- a/src/header_map.rs
+++ b/src/header_map.rs
@@ -179,6 +179,7 @@ impl TryFrom<Value> for X5Chain {
 /// Simple macro for defining generic claims with implementations of
 /// the Claim and From<> for serde_cbor::Value traits.
 /// Custom value_type's must implement From<value_type> for serde_cbor::Value.
+#[allow(unused_macros)]
 macro_rules! define_header {
     ($name:ident, $value_type: ty, $key: expr) => {
         #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]

--- a/src/header_map.rs
+++ b/src/header_map.rs
@@ -169,5 +169,4 @@ macro_rules! define_header {
     };
 }
 
-define_header!(Algorithm, String, Key::Integer(1));
 define_header!(X5Chain, Vec<u8>, Key::Integer(33));

--- a/src/header_map.rs
+++ b/src/header_map.rs
@@ -12,10 +12,10 @@ use std::ops::Deref;
 pub struct HeaderMap(BTreeMap<Key, Value>);
 
 impl HeaderMap {
-    /// Insert a defined CWT header struct.
+    /// Insert a defined CWT header parameter.
     /// Returns an error if the previous value found cannot be parsed
     /// into the expected header structure.
-    pub fn insert_claim<T: Header>(&mut self, claim: T) -> Result<Option<T>, Error> {
+    pub fn insert_header<T: Header>(&mut self, claim: T) -> Result<Option<T>, Error> {
         match self.0.insert(T::key(), claim.into()) {
             None => Ok(None),
             Some(v) => v.try_into().map_or_else(
@@ -55,10 +55,10 @@ impl HeaderMap {
         self.0.get(&Key::Text(label.into()))
     }
 
-    /// Remove a defined CWT header struct.
+    /// Remove a defined CWT header parameter.
     /// Returns an error if the removed value cannot be parsed into
     /// the expected header structure.
-    pub fn remove_claim<T: Header>(&mut self) -> Result<Option<T>, Error> {
+    pub fn remove_header<T: Header>(&mut self) -> Result<Option<T>, Error> {
         match self.0.remove(&T::key()) {
             None => Ok(None),
             Some(v) => v.try_into().map_or_else(
@@ -78,7 +78,7 @@ impl HeaderMap {
         self.0.remove(&Key::Integer(key.into()))
     }
 
-    /// Remove a claim value with a text key.
+    /// Remove a header value with a text key.
     pub fn remove_t<T: Into<String>>(&mut self, key: T) -> Option<Value> {
         self.0.remove(&Key::Text(key.into()))
     }

--- a/src/header_map.rs
+++ b/src/header_map.rs
@@ -139,7 +139,7 @@ pub trait Header: Into<Value> + TryFrom<Value, Error = serde_cbor::Error> {
 /// Custom value_type's must implement From<value_type> for serde_cbor::Value.
 macro_rules! define_header {
     ($name:ident, $value_type: ty, $key: expr) => {
-        #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+        #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
         pub struct $name($value_type);
         impl $name {
             pub fn new(value: $value_type) -> $name {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 #[allow(non_camel_case_types)]
 pub mod algorithm;
 pub mod cwt;
-mod header_map;
+pub mod header_map;
 mod protected;
 /// Implementation of COSE_Sign1.
 pub mod sign1;


### PR DESCRIPTION
Adds a few more utilities and converts HeaderMap to use Key as keys. Also adds basic Algorithm and X5Chain header types.