### PR TITLE
Implement IETF Referenced Token Status claims

### DIFF
--- a/src/cwt/claim/ietf_token_status.rs
+++ b/src/cwt/claim/ietf_token_status.rs
@@ -3,149 +3,77 @@
 use super::{Claim, Error as ClaimError, Key};
 use serde::{Deserialize, Serialize};
 use serde_cbor::Value;
-use std::collections::BTreeMap;
 
-/// Status Claim for the ReferencedToken.
+/// Status Claim for the Referenced Token, which describes
+/// its location in the Status List.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
-pub struct ReferencedTokenStatus {
-    pub status_list: StatusListReference,
+pub struct Status {
+    pub status_list: StatusList,
 }
 
-/// Claim describing the location of the Referenced Token in the Status List.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
-pub struct StatusListReference {
-    pub idx: StatusListIndex,
-    pub uri: StatusListUri,
+pub struct StatusList {
+    pub idx: u32,
+    pub uri: String,
 }
 
-/// Index to check for status information in the Status List for the Referenced Token.
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
-pub struct StatusListIndex(pub u32);
-
-/// The URI where one can fetch the Status List or Status List Token
-/// containing the status information about the ReferencedToken.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
-pub struct StatusListUri(pub String);
-
-impl ReferencedTokenStatus {
-    pub fn new(idx: StatusListIndex, uri: StatusListUri) -> Self {
-        Self {
-            status_list: StatusListReference { idx, uri },
+impl Status {
+    pub fn new(idx: u32, uri: String) -> Self {
+        Status {
+            status_list: StatusList { idx, uri },
         }
     }
 }
 
-impl Claim for ReferencedTokenStatus {
+impl Claim for Status {
     fn key() -> Key {
         Key::Integer(65535)
     }
 }
-impl From<ReferencedTokenStatus> for Value {
-    fn from(value: ReferencedTokenStatus) -> Self {
-        Value::Map(value.into())
+
+impl From<Status> for Value {
+    fn from(value: Status) -> Self {
+        // Unwrap safety: predictable data structure should not throw an error.
+        // Unit-tested route.
+        serde_cbor::value::to_value(value).unwrap()
     }
 }
-impl From<ReferencedTokenStatus> for BTreeMap<Value, Value> {
-    fn from(value: ReferencedTokenStatus) -> Self {
-        BTreeMap::from_iter([(StatusListReference::key().into(), value.status_list.into())])
-    }
-}
-impl TryFrom<Value> for ReferencedTokenStatus {
+
+impl TryFrom<Value> for Status {
     type Error = ClaimError;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         Ok(serde_cbor::value::from_value(value)?)
-    }
-}
-
-impl Claim for StatusListReference {
-    fn key() -> Key {
-        Key::Text("status_list".into())
-    }
-}
-impl From<StatusListReference> for Value {
-    fn from(value: StatusListReference) -> Self {
-        Value::Map(value.into())
-    }
-}
-impl From<StatusListReference> for BTreeMap<Value, Value> {
-    fn from(value: StatusListReference) -> Self {
-        BTreeMap::from_iter([
-            (StatusListIndex::key().into(), value.idx.into()),
-            (StatusListUri::key().into(), value.uri.into()),
-        ])
-    }
-}
-impl TryFrom<Value> for StatusListReference {
-    type Error = ClaimError;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
-        Ok(serde_cbor::value::from_value(value)?)
-    }
-}
-
-impl From<u32> for StatusListIndex {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-impl Claim for StatusListIndex {
-    fn key() -> Key {
-        Key::Text("idx".into())
-    }
-}
-impl From<StatusListIndex> for Value {
-    fn from(value: StatusListIndex) -> Self {
-        value.0.into()
-    }
-}
-impl TryFrom<Value> for StatusListIndex {
-    type Error = ClaimError;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
-        Ok(Self(serde_cbor::value::from_value(value)?))
-    }
-}
-
-impl From<String> for StatusListUri {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-impl Claim for StatusListUri {
-    fn key() -> Key {
-        Key::Text("uri".into())
-    }
-}
-impl From<StatusListUri> for Value {
-    fn from(value: StatusListUri) -> Self {
-        value.0.into()
-    }
-}
-impl TryFrom<Value> for StatusListUri {
-    type Error = ClaimError;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
-        Ok(Self(serde_cbor::value::from_value(value)?))
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_encode_decode() {
-        let status = ReferencedTokenStatus {
-            status_list: StatusListReference {
-                idx: StatusListIndex(0),
-                uri: StatusListUri("https://example.com/statuslists/1".into()),
-            },
-        };
+        let status = Status::new(0, "https://example.com/statuslists/1".into());
         let serialized = serde_cbor::to_vec(&status).expect("failed to serialize Status");
-        let deserialized_status: ReferencedTokenStatus =
+        let deserialized_status: Status =
             serde_cbor::from_slice(&serialized).expect("failed to deserialize into Status");
-
         assert_eq!(status, deserialized_status);
+    }
+
+    #[test]
+    fn test_status_structure() {
+        let test_uri = "https://example.com/statuslists/1";
+        let test_idx = 108;
+        let status = Status::new(test_idx, test_uri.into());
+        let status_cbor: Value = status.into();
+        let expected_status_cbor = Value::Map(BTreeMap::from_iter([(
+            Value::Text("status_list".into()),
+            Value::Map(BTreeMap::from_iter([
+                (Value::Text("idx".into()), Value::Integer(test_idx.into())),
+                (Value::Text("uri".into()), Value::Text(test_uri.into())),
+            ])),
+        )]));
+        assert_eq!(expected_status_cbor, status_cbor);
     }
 }

--- a/src/cwt/claim/ietf_token_status.rs
+++ b/src/cwt/claim/ietf_token_status.rs
@@ -8,11 +8,11 @@ use serde_cbor::Value;
 /// its location in the Status List.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct Status {
-    pub status_list: StatusList,
+    pub status_list: StatusListInfo,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
-pub struct StatusList {
+pub struct StatusListInfo {
     pub idx: u32,
     pub uri: String,
 }
@@ -20,7 +20,7 @@ pub struct StatusList {
 impl Status {
     pub fn new(idx: u32, uri: String) -> Self {
         Status {
-            status_list: StatusList { idx, uri },
+            status_list: StatusListInfo { idx, uri },
         }
     }
 }

--- a/src/cwt/claim/ietf_token_status.rs
+++ b/src/cwt/claim/ietf_token_status.rs
@@ -1,0 +1,151 @@
+//! Claims from the IETF Token Status List spec.
+
+use super::{Claim, Error as ClaimError, Key};
+use serde::{Deserialize, Serialize};
+use serde_cbor::Value;
+use std::collections::BTreeMap;
+
+/// Status Claim for the ReferencedToken.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct ReferencedTokenStatus {
+    pub status_list: StatusListReference,
+}
+
+/// Claim describing the location of the Referenced Token in the Status List.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct StatusListReference {
+    pub idx: StatusListIndex,
+    pub uri: StatusListUri,
+}
+
+/// Index to check for status information in the Status List for the Referenced Token.
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct StatusListIndex(pub u32);
+
+/// The URI where one can fetch the Status List or Status List Token
+/// containing the status information about the ReferencedToken.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct StatusListUri(pub String);
+
+impl ReferencedTokenStatus {
+    pub fn new(idx: StatusListIndex, uri: StatusListUri) -> Self {
+        Self {
+            status_list: StatusListReference { idx, uri },
+        }
+    }
+}
+
+impl Claim for ReferencedTokenStatus {
+    fn key() -> Key {
+        Key::Integer(65535)
+    }
+}
+impl From<ReferencedTokenStatus> for Value {
+    fn from(value: ReferencedTokenStatus) -> Self {
+        Value::Map(value.into())
+    }
+}
+impl From<ReferencedTokenStatus> for BTreeMap<Value, Value> {
+    fn from(value: ReferencedTokenStatus) -> Self {
+        BTreeMap::from_iter([(StatusListReference::key().into(), value.status_list.into())])
+    }
+}
+impl TryFrom<Value> for ReferencedTokenStatus {
+    type Error = ClaimError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Ok(serde_cbor::value::from_value(value)?)
+    }
+}
+
+impl Claim for StatusListReference {
+    fn key() -> Key {
+        Key::Text("status_list".into())
+    }
+}
+impl From<StatusListReference> for Value {
+    fn from(value: StatusListReference) -> Self {
+        Value::Map(value.into())
+    }
+}
+impl From<StatusListReference> for BTreeMap<Value, Value> {
+    fn from(value: StatusListReference) -> Self {
+        BTreeMap::from_iter([
+            (StatusListIndex::key().into(), value.idx.into()),
+            (StatusListUri::key().into(), value.uri.into()),
+        ])
+    }
+}
+impl TryFrom<Value> for StatusListReference {
+    type Error = ClaimError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Ok(serde_cbor::value::from_value(value)?)
+    }
+}
+
+impl From<u32> for StatusListIndex {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+impl Claim for StatusListIndex {
+    fn key() -> Key {
+        Key::Text("idx".into())
+    }
+}
+impl From<StatusListIndex> for Value {
+    fn from(value: StatusListIndex) -> Self {
+        value.0.into()
+    }
+}
+impl TryFrom<Value> for StatusListIndex {
+    type Error = ClaimError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Ok(Self(serde_cbor::value::from_value(value)?))
+    }
+}
+
+impl From<String> for StatusListUri {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+impl Claim for StatusListUri {
+    fn key() -> Key {
+        Key::Text("uri".into())
+    }
+}
+impl From<StatusListUri> for Value {
+    fn from(value: StatusListUri) -> Self {
+        value.0.into()
+    }
+}
+impl TryFrom<Value> for StatusListUri {
+    type Error = ClaimError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Ok(Self(serde_cbor::value::from_value(value)?))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_encode_decode() {
+        let status = ReferencedTokenStatus {
+            status_list: StatusListReference {
+                idx: StatusListIndex(0),
+                uri: StatusListUri("https://example.com/statuslists/1".into()),
+            },
+        };
+        let serialized = serde_cbor::to_vec(&status).expect("failed to serialize Status");
+        let deserialized_status: ReferencedTokenStatus =
+            serde_cbor::from_slice(&serialized).expect("failed to deserialize into Status");
+
+        assert_eq!(status, deserialized_status);
+    }
+}

--- a/src/cwt/claim/mod.rs
+++ b/src/cwt/claim/mod.rs
@@ -1,3 +1,5 @@
+pub mod ietf_token_status;
+
 use serde::{Deserialize, Serialize};
 use serde_cbor::Value;
 

--- a/src/cwt/mod.rs
+++ b/src/cwt/mod.rs
@@ -299,10 +299,7 @@ mod test {
         let issuer = claim::Issuer::new("test text".into());
         let exp = claim::ExpirationTime::new(NumericDate::IntegerSeconds(1444064944));
         let cwt_id = claim::CWTId::new(hex::decode("0b71").unwrap());
-        let status = claim::ietf_token_status::ReferencedTokenStatus::new(
-            5.into(),
-            "http://example.com".to_string().into(),
-        );
+        let status = claim::ietf_token_status::Status::new(5, "http://example.com".into());
 
         test_get_claim(issuer, "issuer (String value)");
         test_get_claim(exp, "expiration time (NumericDate value)");

--- a/src/cwt/mod.rs
+++ b/src/cwt/mod.rs
@@ -299,10 +299,15 @@ mod test {
         let issuer = claim::Issuer::new("test text".into());
         let exp = claim::ExpirationTime::new(NumericDate::IntegerSeconds(1444064944));
         let cwt_id = claim::CWTId::new(hex::decode("0b71").unwrap());
+        let status = claim::ietf_token_status::ReferencedTokenStatus::new(
+            5.into(),
+            "http://example.com".to_string().into(),
+        );
 
         test_get_claim(issuer, "issuer (String value)");
         test_get_claim(exp, "expiration time (NumericDate value)");
         test_get_claim(cwt_id, "CWT ID (Bytes value)");
+        test_get_claim(status, "Status (nested BTree)");
     }
 
     #[test]


### PR DESCRIPTION
### Description
- Implements Status claim included in the referenced token (`ReferencedTokenStatus`), as described in the IETF Token Status spec
  - Adds all nested claims
  - Adds convenience trait implementations so that this can be used in a CWT claims set

### Tested
- Added a unit test for encoding/decoding
- Added a unit test case for the nested type