### PR TITLE
Add KeyId typed header

### DIFF
--- a/src/cwt/claim/mod.rs
+++ b/src/cwt/claim/mod.rs
@@ -35,10 +35,7 @@ impl TryFrom<Value> for Key {
         match value {
             Value::Text(s) => Ok(Key::Text(s)),
             Value::Integer(i) => Ok(Key::Integer(i)),
-            invalid_key_type => Err(Self::Error::InvalidCwtKey(format!(
-                "{:?}",
-                invalid_key_type
-            ))),
+            invalid_key_type => Err(Self::Error::InvalidCwtKey(format!("{invalid_key_type:?}"))),
         }
     }
 }

--- a/src/header_map/headers.rs
+++ b/src/header_map/headers.rs
@@ -1,0 +1,82 @@
+//! Standard COSE headers for convenience, as specified in the
+//! [COSE Header Parameters registry](https://www.iana.org/assignments/cose/cose.xhtml).
+use super::Header;
+pub use crate::cwt::claim::Key;
+use serde::{de::Error as _, Deserialize, Serialize};
+use serde_cbor::Value;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[serde(untagged)]
+/// X.509 chain header.
+pub enum X5Chain {
+    One(Vec<u8>),
+    Many(Vec<Vec<u8>>),
+}
+
+impl Header for X5Chain {
+    fn key() -> Key {
+        Key::Integer(33)
+    }
+}
+
+impl From<X5Chain> for Value {
+    fn from(value: X5Chain) -> Self {
+        match value {
+            X5Chain::One(v) => v.into(),
+            X5Chain::Many(v) => v
+                .into_iter()
+                .map(Value::Bytes)
+                .collect::<Vec<Value>>()
+                .into(),
+        }
+    }
+}
+
+impl TryFrom<Value> for X5Chain {
+    type Error = serde_cbor::Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Bytes(v) => Ok(X5Chain::One(v)),
+            Value::Array(v) => v
+                .into_iter()
+                .map(serde_cbor::value::from_value)
+                .collect::<Result<Vec<Vec<u8>>, serde_cbor::Error>>()
+                .map(X5Chain::Many),
+            _ => Err(serde_cbor::Error::custom("Invalid X5Chain value")),
+        }
+    }
+}
+
+/// Key ID header.
+pub struct KeyId(Vec<u8>);
+
+impl KeyId {
+    pub fn new(value: impl Into<Vec<u8>>) -> KeyId {
+        KeyId(value.into())
+    }
+}
+
+impl Header for KeyId {
+    fn key() -> Key {
+        Key::Integer(4)
+    }
+}
+
+impl From<KeyId> for Value {
+    fn from(value: KeyId) -> Self {
+        value.0.into()
+    }
+}
+
+impl TryFrom<Value> for KeyId {
+    type Error = serde_cbor::Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        if let Value::Bytes(bytes) = value {
+            Ok(KeyId(bytes))
+        } else {
+            Err(serde_cbor::Error::custom("Invalid KeyId value"))
+        }
+    }
+}

--- a/src/header_map/headers.rs
+++ b/src/header_map/headers.rs
@@ -80,3 +80,23 @@ impl TryFrom<Value> for KeyId {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::{super::HeaderMap, *};
+
+    #[test]
+    fn test_key_id() {
+        let mut header_map = HeaderMap::default();
+        let key_id_bstr = b"test key ID";
+        let key_id = KeyId::new(key_id_bstr);
+        header_map
+            .insert_header(key_id)
+            .expect("failed to insert key ID");
+        let retrieved = header_map
+            .remove_header::<KeyId>()
+            .expect("failed to remove key ID")
+            .expect("key ID not found");
+        assert_eq!(retrieved.0, key_id_bstr);
+    }
+}

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -35,10 +35,7 @@ impl<'de> de::Deserialize<'de> for Protected {
                 };
                 Ok(Protected(header_map, Some(header_map_bytes)))
             }
-            v => Err(D::Error::custom(format!(
-                "expected byte str, found: {:?}",
-                v
-            ))),
+            v => Err(D::Error::custom(format!("expected byte str, found: {v:?}"))),
         }
     }
 }

--- a/src/sign1.rs
+++ b/src/sign1.rs
@@ -153,7 +153,7 @@ impl CoseSign1 {
 
         match verifier.verify(&signature_payload, &signature) {
             Ok(()) => VerificationResult::Success,
-            Err(e) => VerificationResult::Failure(format!("signature is not authentic: {}", e)),
+            Err(e) => VerificationResult::Failure(format!("signature is not authentic: {e}")),
         }
     }
 
@@ -214,8 +214,7 @@ impl<'de> de::Deserialize<'de> for CoseSign1 {
             Some(18) => true,
             Some(n) => {
                 return Err(D::Error::custom(format!(
-                    "unable to deserialize CoseSign1: expected tag 18, received tag {}",
-                    n
+                    "unable to deserialize CoseSign1: expected tag 18, received tag {n}"
                 )))
             }
         };
@@ -397,7 +396,7 @@ impl VerificationResult {
         match self {
             VerificationResult::Success => Ok(()),
             VerificationResult::Failure(reason) => Err(reason),
-            VerificationResult::Error(e) => Err(format!("{}", e)),
+            VerificationResult::Error(e) => Err(format!("{e}")),
         }
     }
 


### PR DESCRIPTION
### Description
- Adds `KeyId` typed header claim as specified in the [IANA registry](https://www.iana.org/assignments/cose/cose.xhtml), (label = 4, value type = bstr)
- Extracts out typed headers into a subcrate in header_map to avoid clutter (including old `X5Chain` claim)
  - Removed an unused claim creation macro for headers -- it was an exact duplicate of the existing one for CWT claims so we can always re-copy it if we need/want it later
- Fixes lints from updated clippy version

### Tested
- Added a unit test
- Tested this in a dependent repo, usage & de-/serialization looks to work as expected
